### PR TITLE
Asher fixed map button

### DIFF
--- a/VocationalNYC/templates/courses/courses_section.html
+++ b/VocationalNYC/templates/courses/courses_section.html
@@ -37,7 +37,7 @@
                                                           <ul class="Course-Location-Outer Card__StyledRankList-sc-1ra20i5-11 CourseLocation"
                                                                 font-size=4 spacing=0>
                                                                 <li class="Course-Location-Outer rank-list-item">
-                                                                    <a class="Course-Location-Inner has-badge">
+                                                                    <a class="Course-Location-Inner has-badge" onclick="location.href='/courses/map/?course_id={{ course.pk }}'">
                                                                         <div class="Course-Location-Outer-Icon ranked has-badge">
                                                                         </div>
                                                                         <span class=in>{{ course.provider.address }}</span></a>
@@ -171,10 +171,7 @@
                                                     </div>
 
 
-<button class="button__ButtonStyled-sc-1vhaw8r-1 type-primary size-small"
-        onclick="location.href='/courses/map/?course_id={{ course.pk }}'">
-    Show on Map
-</button>
+
                                                     <button class="BookmarkButton size-small"
 
                                                             data-url="{% url 'add_bookmark' course.pk %}"


### PR DESCRIPTION
Previously, users had to click a separate button to navigate to the course’s map page. I’ve streamlined the experience by moving that logic to the course address itself — now, clicking the address takes you directly to the map.