### PR TITLE
CI/CD pipeline fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,9 @@ after_success:
   - docker-compose -f docker-compose.ci.yml exec -T -e TRAVIS=true -e TRAVIS_JOB_ID=$TRAVIS_JOB_ID -e TRAVIS_BRANCH=$TRAVIS_BRANCH -e CI=true -e TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST -u root app pip install coveralls
   - docker-compose -f docker-compose.ci.yml exec -T -e TRAVIS=true -e TRAVIS_JOB_ID=$TRAVIS_JOB_ID -e TRAVIS_BRANCH=$TRAVIS_BRANCH -e CI=true -e TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST -u root app coveralls --verbose
   - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-  - docker-compose -f docker-compose.prod.yml build
+  - docker-compose -f docker-compose.prod.yml build \
+    --build-arg AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
+    --build-arg AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
   - docker-compose -f docker-compose.prod.yml push
   - coveralls
 

--- a/VocationalNYC/.ebextensions/django.config
+++ b/VocationalNYC/.ebextensions/django.config
@@ -2,3 +2,5 @@ option_settings:
   aws:elbv2:listener:80:
     ListenerEnabled: 'true'
     Protocol: HTTP
+  aws:elasticbeanstalk:environment:proxy:staticfiles:
+    /static: staticfiles

--- a/VocationalNYC/docker-compose.prod.yml
+++ b/VocationalNYC/docker-compose.prod.yml
@@ -1,8 +1,6 @@
 services:
   redis:
-    build:
-      context: .
-    image: kxiao02/vocationalnyc-production-redis:latest
+    image: redis:latest
     container_name: redis
     ports:
       - "6379:6379"


### PR DESCRIPTION
This pull request introduces changes to the CI/CD pipeline, Elastic Beanstalk configuration, and Docker setup to improve deployment processes and simplify configurations. Key updates include adding AWS credentials to the build process, configuring static file handling for Elastic Beanstalk, and replacing a custom Redis image with the official Redis image.

### CI/CD Pipeline Updates:
* [`.travis.yml`](diffhunk://#diff-6ac3f79fc25d95cd1e3d51da53a4b21b939437392578a35ae8cd6d5366ca5485L57-R59): Updated the `docker-compose.prod.yml` build step to include AWS credentials (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`) as build arguments, enabling integration with AWS services.

### Elastic Beanstalk Configuration:
* [`VocationalNYC/.ebextensions/django.config`](diffhunk://#diff-66e3bb1c00f85d13eb3480b2d3f88807cdd422ed28aac23abccddf18e64d6412R5-R6): Added a configuration to serve static files (`/static`) from the `staticfiles` directory, improving static file handling in the Elastic Beanstalk environment.

### Docker Configuration Simplification:
* [`VocationalNYC/docker-compose.prod.yml`](diffhunk://#diff-c4da7f6fa0850e115627e852fb2b91bcece1825f07c52d12ed593a05ed9e166bL3-R3): Replaced the custom Redis image (`kxiao02/vocationalnyc-production-redis:latest`) with the official Redis image (`redis:latest`), simplifying the dependency and ensuring up-to-date security and performance.