### PR TITLE
Update server configurations

### DIFF
--- a/VocationalNYC/.platform/nginx/conf.d/websocket.conf
+++ b/VocationalNYC/.platform/nginx/conf.d/websocket.conf
@@ -1,5 +1,5 @@
 upstream docker {
-    server localhost:5000;
+    server localhost:8000;
 }
 
 map $http_upgrade $connection_upgrade {

--- a/VocationalNYC/Procfile
+++ b/VocationalNYC/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn vocationalnyc.asgi:application -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:5000
+web: gunicorn vocationalnyc.asgi:application -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000

--- a/VocationalNYC/docker-compose.ci.yml
+++ b/VocationalNYC/docker-compose.ci.yml
@@ -36,7 +36,7 @@ services:
       - redis
       - nginx
     ports:
-      - 5000:5000
+      - "8000:8000"
     environment:
       DJANGO_ENV: travis
       AWS_ACCESS_KEY_ID: $AWS_ACCESS_KEY_ID

--- a/VocationalNYC/docker-compose.prod.yml
+++ b/VocationalNYC/docker-compose.prod.yml
@@ -17,7 +17,7 @@ services:
     depends_on:
       - redis
     ports:
-      - "5000:5000"
+      - "8000:8000"
     environment:
       DJANGO_ENV: production
       AWS_ACCESS_KEY_ID: $AWS_ACCESS_KEY_ID

--- a/VocationalNYC/docker-compose.yml
+++ b/VocationalNYC/docker-compose.yml
@@ -29,4 +29,4 @@ services:
     volumes:
     - .:/vocationalnyc
     ports:
-      - "5000:5000"
+      - "8000:8000"

--- a/VocationalNYC/entrypoint.sh
+++ b/VocationalNYC/entrypoint.sh
@@ -4,8 +4,8 @@ set -e
 # Depending on DJANGO_ENV, start the appropriate server
 if [ "$DJANGO_ENV" = "development" ]; then
     echo "Starting in development mode with runserver..."
-    exec python manage.py runserver 0.0.0.0:5000
+    exec python manage.py runserver 0.0.0.0:8000
 else
     echo "Starting in production mode with Gunicorn..."
-    exec gunicorn vocationalnyc.asgi:application -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:5000
+    exec gunicorn vocationalnyc.asgi:application -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000
 fi


### PR DESCRIPTION
This pull request updates the application to use port 8000 instead of port 5000 across all configurations and environments. The changes ensure consistency in port usage for development, production, and CI setups.

### Port Change Updates:

* [`VocationalNYC/.platform/nginx/conf.d/websocket.conf`](diffhunk://#diff-8b8f47d8ecb0e41510bbda16e6e6e7a05a931664ac6b501a0a81d51204fec895L2-R2): Updated the upstream server to use port 8000 instead of 5000. The file was also renamed from `.ebextensions/nginx/conf.d/websocket.conf` to `.platform/nginx/conf.d/websocket.conf`.
* [`VocationalNYC/Procfile`](diffhunk://#diff-031a3595a5dcb2c6eeb733206a3bbbcd5b7a872df64133d34b69b71cb2de54b2L1-R1): Changed the Gunicorn binding from port 5000 to 8000.
* `VocationalNYC/docker-compose.ci.yml`, `VocationalNYC/docker-compose.prod.yml`, `VocationalNYC/docker-compose.yml`: Updated the exposed ports in the `services` section from 5000:5000 to 8000:8000 for CI, production, and general Docker Compose configurations. [[1]](diffhunk://#diff-9133d48e1d0b6bc37661839fd6c9278ac96621a15487a5698b15add4cb7add10L39-R39) [[2]](diffhunk://#diff-c4da7f6fa0850e115627e852fb2b91bcece1825f07c52d12ed593a05ed9e166bL20-R20) [[3]](diffhunk://#diff-11832062125a5ff2cc82e74b136ab92b793d3211805b49f438d4489924c85a63L32-R32)
* [`VocationalNYC/entrypoint.sh`](diffhunk://#diff-b9a3ce342b02b3c114a72da847d7a6f6b8b546628bb3c8650fad5dd112abc624L7-R10): Modified the `runserver` and Gunicorn commands to bind to port 8000 instead of 5000 for both development and production modes.